### PR TITLE
Correctly handle mosek status "near_optimal"

### DIFF
--- a/src/python/coneprog.py
+++ b/src/python/coneprog.py
@@ -2893,7 +2893,7 @@ def lp(c, G, h, A = None, b = None, solver = None, primalstart = None,
         resy0 = max(1.0, blas.nrm2(b))
         resz0 = max(1.0, blas.nrm2(h))
 
-        if solsta is mosek.solsta.optimal:
+        if solsta in (mosek.solsta.optimal, mosek.solsta.near_optimal):
             status = 'optimal'
 
             pcost = blas.dot(c,x)


### PR DESCRIPTION
This changes the socp solver to deal with the mosek status "near_optimal"
